### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global
+* @SamSalvatico @alewin @bozzelliandrea @matteolc


### PR DESCRIPTION
### Description

to automatically assign reviewers to open PRs, I added the `codeowners` file, same as https://github.com/ogcio/building-blocks-sdk/pull/60
<!-- Please include a summary of the changes and the related issue. -->

## Type

- [ ] **Dependency upgrade**
- [ ] **Bug fix**
- [ ] **New feature**
- [ ] **Dev change**
- [ ] **Additional tests**
- [ ] **Documentation**
- [ ] **Other**

### Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] This change might impact the developer experience of others and should be communicated
