### PR TITLE
chore: added ignore in dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -19,3 +19,10 @@ updates:
       all-dependencies:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "@types/react"
+      - dependency-name: "@types/react-dom"
+      - dependency-name: "react"
+      - dependency-name: "react-dom"
+      - dependency-name: "@logto/next"
+      - dependency-name: "next"


### PR DESCRIPTION
### Description

Ignore some packages in dependabot
we have to have fixed versions of react and next because they are not following strict semantic versioning, then also patches are causing a lot of issues

## Type

- [ ] **Dependency upgrade**
- [ ] **Bug fix**
- [ ] **New feature**
- [x] **Dev change**
- [ ] **Additional tests**
- [ ] **Documentation**
- [ ] **Other**
