### PR TITLE
fix: skip internal objects serialize if empty AB#26429

### DIFF
--- a/packages/fastify-logging-wrapper/__tests__/fastify-logging-wrapper.test.ts
+++ b/packages/fastify-logging-wrapper/__tests__/fastify-logging-wrapper.test.ts
@@ -36,6 +36,8 @@ describe("Logging entries when all works fine are the expected ones", () => {
       responseStatusCode: 200,
       expectedMessage: LogMessages.ApiTrack,
     });
+    const apiTrackEntry = JSON.parse(loggedRecords[2]);
+    assert.notNestedProperty(apiTrackEntry, "error");
   });
 });
 

--- a/packages/fastify-logging-wrapper/src/fastify-logging-wrapper.ts
+++ b/packages/fastify-logging-wrapper/src/fastify-logging-wrapper.ts
@@ -26,11 +26,15 @@ import {
 const hyperidInstance = hyperid({ fixedLength: true, urlSafe: true });
 
 const isObjectNotEmpty = (value: object | undefined) => {
-  return !(
+  return (
     value &&
     typeof value === "object" &&
     !Array.isArray(value) &&
-    Object.keys(value).length > 0
+    Object.keys(
+      Object.fromEntries(
+        Object.entries(value).filter(([_, v]) => v !== undefined),
+      ),
+    ).length > 0
   );
 };
 
@@ -56,11 +60,8 @@ export const initializeLoggingHooks = (server: FastifyInstance): void => {
 
     const error = getPartialLoggingContextError();
     if (isObjectNotEmpty(error)) {
-      console.log("ERROR OBJECT BUT VALID", JSON.stringify(error));
       reply.log.info({ error: error }, LogMessages.ApiTrack);
     } else {
-      console.log("INVALID ERROR OBJECT", JSON.stringify(error));
-
       reply.log.info(LogMessages.ApiTrack);
     }
 


### PR DESCRIPTION
### Description

The following commit is related to observability sdk warnings
- `Invalid attribute value set for key: request`
- `Invalid attribute value set for key: error`

The log wrapper library add by default empty object to the log structure, adding this check should add only non empty objects to log records.

Issue: [26429](https://dev.azure.com/OGCIO-Digital-Services/Digital%20Services%20Programme/_workitems/edit/26429/)

## Type

- [ ] **Dependency upgrade**
- [X] **Bug fix**
- [ ] **New feature**
- [ ] **Dev change**
- [ ] **Additional tests**
- [ ] **Documentation**
- [ ] **Other**

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] This change might impact the developer experience of others and should be communicated
