### PR TITLE
chore: bump nextjs-analytics to `0.1.5`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       "peer": true,
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/auto-instrumentations-node": "^0.57.0",
+        "@opentelemetry/auto-instrumentations-node": "^0.57.1",
         "@opentelemetry/core": "^2.0.0",
         "@opentelemetry/exporter-logs-otlp-grpc": "^0.200.0",
         "@opentelemetry/exporter-logs-otlp-http": "^0.200.0",
@@ -46,11 +46,11 @@
         "@opentelemetry/sdk-trace-base": "^2.0.0"
       },
       "devDependencies": {
-        "@types/node": "^22.13.9",
-        "@vitest/coverage-v8": "^3.0.8",
+        "@types/node": "^22.14.0",
+        "@vitest/coverage-v8": "^3.1.1",
         "tsx": "^4.19.3",
-        "typescript": "^5.8.2",
-        "vitest": "^3.0.8"
+        "typescript": "^5.8.3",
+        "vitest": "^3.1.1"
       },
       "engines": {
         "node": ">=20.6.0"
@@ -2300,6 +2300,19 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@ogcio/analytics-sdk": {
+      "version": "0.1.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@ogcio/analytics-sdk/-/analytics-sdk-0.1.0-beta.16.tgz",
+      "integrity": "sha512-QyJrOa8ti/KpNPqbc9lGkP8ZBmaOW3UULw6KC2LtpyxjhilyD8ynj8ntqWtOGOlKJzQg+4Qbykrhfep9A8Z5Lg==",
+      "license": "ISC",
+      "dependencies": {
+        "openapi-fetch": "^0.13.5",
+        "openapi-typescript-helpers": "^0.0.15"
+      },
+      "engines": {
+        "node": ">=17.0.0"
       }
     },
     "node_modules/@ogcio/api-auth": {
@@ -10030,9 +10043,9 @@
     },
     "packages/nextjs-analytics": {
       "name": "@ogcio/nextjs-analytics",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
-        "@ogcio/analytics-sdk": "0.1.0-beta.15",
+        "@ogcio/analytics-sdk": ">=0.1.0-beta.16",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -10044,19 +10057,6 @@
         "@vitejs/plugin-react": "^4.3.4",
         "jsdom": "^25.0.1",
         "typescript": "^5.7.2"
-      }
-    },
-    "packages/nextjs-analytics/node_modules/@ogcio/analytics-sdk": {
-      "version": "0.1.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@ogcio/analytics-sdk/-/analytics-sdk-0.1.0-beta.15.tgz",
-      "integrity": "sha512-qV/Y8q6Orb1eOMp0MFWJDjtHBvAJMBKmZ+TAJ8X8f04KD71Jf41R/fF8Aw/vaig42Ho7ovTf7ujxPqvXQ6fgOg==",
-      "license": "ISC",
-      "dependencies": {
-        "openapi-fetch": "^0.13.4",
-        "openapi-typescript-helpers": "^0.0.15"
-      },
-      "engines": {
-        "node": ">=17.0.0"
       }
     },
     "packages/nextjs-auth": {

--- a/packages/nextjs-analytics/package.json
+++ b/packages/nextjs-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ogcio/nextjs-analytics",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "",
   "type": "module",
   "scripts": {
@@ -15,7 +15,7 @@
     "dist"
   ],
   "dependencies": {
-    "@ogcio/analytics-sdk": "0.1.0-beta.15",
+    "@ogcio/analytics-sdk": ">=0.1.0-beta.16",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },


### PR DESCRIPTION
### Description

- bump patch nextjs-analytics to `0.1.5`
- add support to analytics-sdk `0.1.0-beta.16`

## Type

- [ ] **Dependency upgrade**
- [ ] **Bug fix**
- [ ] **New feature**
- [ ] **Dev change**
- [ ] **Additional tests**
- [ ] **Documentation**
- [ ] **Other**

### Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] This change might impact the developer experience of others and should be communicated
