### PR TITLE
feat: use next as peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10478,9 +10478,9 @@
         "react-dom": "^18.3.1"
       },
       "peerDependencies": {
-        "next": "^14.2.5",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "next": ">=14.2",
+        "react": ">=18.3",
+        "react-dom": ">=18.3"
       }
     },
     "packages/nextjs-auth/node_modules/@logto/next": {
@@ -10517,8 +10517,13 @@
       "license": "ISC",
       "dependencies": {
         "@ogcio/shared-errors": "^1.0.0",
-        "next": "14.2.5",
         "pino": "^9.5.0"
+      },
+      "devDependencies": {
+        "next": "^14.2.5"
+      },
+      "peerDependencies": {
+        "next": ">=14.2"
       }
     },
     "packages/nextjs-o11y": {

--- a/packages/nextjs-auth/package.json
+++ b/packages/nextjs-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ogcio/nextjs-auth",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "private": false,
   "main": "dist/index.js",
   "scripts": {
@@ -17,9 +17,9 @@
     "http-errors": "^2.0.0"
   },
   "peerDependencies": {
-    "next": "^14.2.5",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "next": ">=14.2",
+    "react": ">=18.3",
+    "react-dom": ">=18.3"
   },
   "devDependencies": {
     "@types/http-errors": "2.0.4",

--- a/packages/nextjs-logging-wrapper/package.json
+++ b/packages/nextjs-logging-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ogcio/nextjs-logging-wrapper",
-  "version": "14.2.9",
+  "version": "14.2.10",
   "description": "",
   "type": "module",
   "exports": {
@@ -25,9 +25,14 @@
   "author": "samuele.salvatico@nearform.com",
   "license": "ISC",
   "dependencies": {
-    "next": "14.2.5",
     "pino": "^9.5.0",
     "@ogcio/shared-errors": "^1.0.0"
+  },
+  "devDependencies": {
+    "next": "^14.2.5"
+  },
+  "peerDependencies": {
+    "next": ">=14.2"
   },
   "files": [
     "dist",


### PR DESCRIPTION
Use NextJS as peer dependency in nextjs-auth and nextjs-logging-wrapper packages.