### PR TITLE
fix: logger wrapper v4 pino instance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5927,7 +5927,7 @@
     },
     "packages/fastify-logging-wrapper": {
       "name": "@ogcio/fastify-logging-wrapper",
-      "version": "4.1.1",
+      "version": "4.1.2",
       "license": "ISC",
       "dependencies": {
         "@fastify/error": "^4.0.0",

--- a/packages/fastify-logging-wrapper/package.json
+++ b/packages/fastify-logging-wrapper/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ogcio/fastify-logging-wrapper",
-    "version": "4.1.1",
+    "version": "4.1.2",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "type": "module",

--- a/packages/fastify-logging-wrapper/src/fastify-logging-wrapper.ts
+++ b/packages/fastify-logging-wrapper/src/fastify-logging-wrapper.ts
@@ -73,10 +73,21 @@ export const initializeLoggingHooks = (server: FastifyInstance): void => {
 export const getLoggingConfiguration = (
   loggerDestination?: DestinationStream,
   customLoggerOptions?: PinoLoggerOptions,
-): FastifyServerOptions => ({
-  logger: pino(getLoggerConfiguration(customLoggerOptions), loggerDestination),
-  disableRequestLogging: true,
-  genReqId: () => hyperidInstance(),
-  requestIdLogLabel: REQUEST_ID_LOG_LABEL,
-  requestIdHeader: REQUEST_ID_HEADER,
-});
+): FastifyServerOptions => {
+  let logger = { ...getLoggerConfiguration(), ...(customLoggerOptions ?? {}) };
+
+  if (loggerDestination) {
+    logger = pino(
+      getLoggerConfiguration(customLoggerOptions),
+      loggerDestination,
+    );
+  }
+
+  return {
+    logger: logger,
+    disableRequestLogging: true,
+    genReqId: () => hyperidInstance(),
+    requestIdLogLabel: REQUEST_ID_LOG_LABEL,
+    requestIdHeader: REQUEST_ID_HEADER,
+  };
+};


### PR DESCRIPTION
### Description

Backporting on v4 shared logging wrapper package about editing pino config without creating a new instance if not needed

## Type

- [ ] **Dependency upgrade**
- [X] **Bug fix**
- [ ] **New feature**
- [ ] **Dev change**
- [ ] **Additional tests**
- [ ] **Documentation**
- [ ] **Other**

### Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] This change might impact the developer experience of others and should be communicated
